### PR TITLE
[MMU3] State-machine-driven load/unload recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,13 +186,28 @@ The extension supplies all the necessary gcode commands.
    Unlocks the MMU by moving the idler to the home position. Mostly needed when
    you need to pull/push the filament manually.
 
-9. `CUT_FILAMENT_IN_EXTRUDER`
+9. `MMU_RETRY`
+
+   Retries the load/unload operation that failed and left the MMU paused. The
+   MMU remembers what it was doing (which `Tx`, load or unload) and how far it
+   got, so you don't have to - `MMU_RETRY` re-checks the FINDA / switch / motion
+   sensors and resumes from where the filament actually is instead of starting
+   the whole sequence over. `printer["mmu3 MMU3"].pending_operation` and
+   `.filament_pos` report the current recovery state.
+
+10. `RESUME_MMU` / `RESUME_MMU FORCE=1`
+
+   `RESUME_MMU` runs `MMU_RETRY` first and only resumes the print if the
+   recovery succeeds. `RESUME_MMU FORCE=1` clears the pending operation and
+   resumes anyway - use it when you have already fixed the filament by hand.
+
+11. `CUT_FILAMENT_IN_EXTRUDER`
 
    This macro is defined in the `mmu3.cfg` and controls the movement required
    to cut the filament inside the extruder. This is called by the `Tx` commands
    if the `enable_filament_cutter` is set to `True`.
 
-10. `PULLEY_CALIBRATE`
+12. `PULLEY_CALIBRATE`
 
    This command is used to calibrate the pulley `rotation_distance` value. The
    process works like this:
@@ -239,6 +254,7 @@ design.
    M702
    MMU_DISABLE
    MMU_ENABLE
+   MMU_RETRY
    PAUSE_MMU
    PRE_LOAD_FILAMENT_TO_FINDA
    PULLEY_CALIBRATE

--- a/extras/mmu3.py
+++ b/extras/mmu3.py
@@ -62,6 +62,125 @@ STEPPER_NAME_MAP = {
 IS_DIGIT = re.compile("[0-9\-.]+")
 
 
+class FilamentPos(enum.IntEnum):
+    """Where the filament tip currently sits along the MMU -> nozzle path.
+
+    Ordered: a larger value means the filament has moved further from the
+    MMU toward the nozzle, so the planner can compare positions directly.
+    """
+
+    UNLOADED = 0
+    AT_FINDA = 1
+    AT_EXTRUDER = 2
+    IN_HOTEND = 3
+    LOADED = 4
+
+    def __repr__(self) -> str:
+        """Return the enum name for str().
+
+        Returns:
+            str: The name as the string representation.
+        """
+        return self.name
+
+    __str__ = __repr__
+
+
+class OperationKind(enum.Enum):
+    """The kind of high level MMU operation that can be pending recovery."""
+
+    TOOL_CHANGE = "tool_change"
+    LOAD = "load"
+    UNLOAD = "unload"
+    HOME = "home"
+    CUT = "cut"
+    EJECT = "eject"
+
+    def __repr__(self) -> str:
+        """Return the enum name for str().
+
+        Returns:
+            str: The name as the string representation.
+        """
+        return self.name
+
+    __str__ = __repr__
+
+
+class Operation:
+    """A record of the high level MMU operation currently in progress.
+
+    Held on ``MMU3.current_operation`` while a top level command runs and
+    promoted to ``MMU3.pending_operation`` by :func:`auto_pause` when the
+    command fails, so recovery (``MMU_RETRY`` / ``RESUME_MMU``) knows what the
+    operator was trying to do without them having to remember it.
+
+    Args:
+        kind (OperationKind): The kind of operation.
+        from_tool (None | int): The tool that was loaded when the operation
+            started.
+        to_tool (None | int): The tool the operation is trying to end up with
+            loaded. ``None`` for pure unloads / homing.
+    """
+
+    def __init__(
+        self,
+        kind: OperationKind,
+        from_tool: None | int = None,
+        to_tool: None | int = None,
+    ) -> None:
+        self.kind = kind
+        self.from_tool = from_tool
+        self.to_tool = to_tool
+        self.filament_pos_at_fail: None | FilamentPos = None
+        self.error: str = ""
+
+    @property
+    def target_pos(self) -> FilamentPos:
+        """Return the filament position this operation is trying to reach."""
+        loads = (OperationKind.TOOL_CHANGE, OperationKind.LOAD)
+        if self.kind in loads and self.to_tool is not None:
+            return FilamentPos.LOADED
+        return FilamentPos.UNLOADED
+
+    def describe(self) -> str:
+        """Return a short human readable summary for prompts and status.
+
+        Returns:
+            str: e.g. ``"Tool change T1 => T2 - stopped with filament at the
+            extruder"``.
+        """
+        if self.kind == OperationKind.TOOL_CHANGE and self.from_tool is not None:
+            what = f"Tool change T{self.from_tool} => T{self.to_tool}"
+        elif self.kind in (OperationKind.TOOL_CHANGE, OperationKind.LOAD):
+            what = f"Load T{self.to_tool}"
+        elif self.kind == OperationKind.UNLOAD:
+            what = (
+                f"Unload T{self.from_tool}"
+                if self.from_tool is not None
+                else "Unload filament"
+            )
+        elif self.kind == OperationKind.CUT:
+            what = f"Cut T{self.to_tool}"
+        elif self.kind == OperationKind.EJECT:
+            what = "Eject filament"
+        else:
+            what = "Home MMU"
+
+        stage = {
+            FilamentPos.UNLOADED: "at the MMU",
+            FilamentPos.AT_FINDA: "at FINDA",
+            FilamentPos.AT_EXTRUDER: "at the extruder",
+            FilamentPos.IN_HOTEND: "in the hotend",
+            FilamentPos.LOADED: "loaded",
+        }.get(self.filament_pos_at_fail)
+        if stage:
+            what = f"{what} - stopped with filament {stage}"
+        if self.error:
+            what = f"{what} ({self.error})"
+        return what
+
+
 def measure_duration(f: Callable) -> Callable:
     """Report command duration.
 
@@ -118,18 +237,70 @@ def auto_pause(f: Callable) -> Callable:
             self.display_status_msg("MMU is not enabled!")
             return False
 
+        error_msg = ""
         try:
             result = f(self, gcmd, *args, **kwargs)
         except self.printer.command_error as e:
             self.respond_debug(f"{f.__name__} raised an error: {e}")
             self.display_status_msg(str(e))
+            error_msg = str(e)
             result = False
 
-        if not result and not self.is_paused:
-            self.pause()
+        if not result:
+            if not self.is_paused:
+                # remember what the operator was trying to do so recovery
+                # (MMU_RETRY / RESUME_MMU) does not depend on their memory
+                if self.current_operation is not None:
+                    self.current_operation.filament_pos_at_fail = self.filament_pos
+                    if error_msg:
+                        self.current_operation.error = error_msg
+                    self.pending_operation = self.current_operation
+                    self.current_operation = None
+                self.pause()
+            if self.pending_operation is not None:
+                self.show_recovery_prompt()
         return result
 
     return wrapped_f
+
+
+def track_operation(kind: OperationKind) -> Callable:
+    """Decorator factory that records the high level operation in progress.
+
+    Sets ``self.current_operation`` to a fresh :class:`Operation` on entry and
+    clears both ``current_operation`` and ``pending_operation`` when the wrapped
+    command succeeds. Must be stacked *inside* :func:`auto_pause` so that, on
+    failure, ``auto_pause`` still sees a populated ``current_operation`` to
+    promote.
+
+    Args:
+        kind (OperationKind): The kind of operation the wrapped command performs.
+
+    Returns:
+        Callable: The actual decorator.
+    """
+
+    def decorator(f: Callable) -> Callable:
+        @wraps(f)
+        def wrapped_f(self: MMU3, gcmd: GCodeCommand, *args, **kwargs) -> None:
+            to_tool = kwargs.get("tool_id")
+            if to_tool is None and gcmd is not None:
+                with contextlib.suppress(Exception):
+                    to_tool = gcmd.get_int("VALUE", None)
+            self.current_operation = Operation(
+                kind=kind,
+                from_tool=self.current_filament,
+                to_tool=to_tool,
+            )
+            result = f(self, gcmd, *args, **kwargs)
+            if result:
+                self.current_operation = None
+                self.pending_operation = None
+            return result
+
+        return wrapped_f
+
+    return decorator
 
 
 def auto_disable_steppers(f: Callable) -> Callable:
@@ -156,7 +327,7 @@ def auto_disable_steppers(f: Callable) -> Callable:
     return wrapped_f
 
 
-class SwitchSensorPosition(enum.Enum):
+class FilamentSwitchSensorPosition(enum.Enum):
     """The position of the filament switch sensor."""
 
     PreGears = "pre_gears"
@@ -175,25 +346,26 @@ class SwitchSensorPosition(enum.Enum):
 
     @classmethod
     def to_switch_sensor_position(
-        cls, position: str | SwitchSensorPosition
-    ) -> SwitchSensorPosition:
-        """Convert the given position value to a SwitchSensorPosition enum.
+        cls, position: str | FilamentSwitchSensorPosition
+    ) -> FilamentSwitchSensorPosition:
+        """Convert the given position value to a FilamentSwitchSensorPosition enum.
 
         Args:
-            position (str | SwitchSensorPosition]): The value to convert to a
-                SwitchSensorPosition.
+            position (str | FilamentSwitchSensorPosition]): The value to convert to a
+                FilamentSwitchSensorPosition.
 
         Raises:
             TypeError: Input value type is invalid.
             ValueError: Input value is invalid.
 
         Returns:
-            SwitchSensorPosition: The enum.
+            FilamentSwitchSensorPosition: The enum.
         """
-        if not isinstance(position, (str, SwitchSensorPosition)):
+        valid = [e.name for e in cls] + [e.value for e in cls]
+        if not isinstance(position, (str, FilamentSwitchSensorPosition)):
             raise TypeError(
-                "position should be a SwitchSensorPosition enum value or one of "
-                f"{[m.name for m in cls] + [e.value for e in cls]}, "
+                "position should be a FilamentSwitchSensorPosition enum value "
+                f"or one of {valid}, "
                 f"not {position.__class__.__name__}: '{position}'"
             )
         if isinstance(position, str):
@@ -202,9 +374,8 @@ class SwitchSensorPosition(enum.Enum):
             position_lower_case = position.lower()
             if position_lower_case not in position_name_lut:
                 raise ValueError(
-                    "position should be a SwitchSensorPosition enum value or one of "
-                    f"{[e.name for e in cls] + [e.value for e in cls]}, "
-                    f"not '{position}'"
+                    "position should be a FilamentSwitchSensorPosition enum "
+                    f"value or one of {valid}, not '{position}'"
                 )
 
             return cls.__members__[position_name_lut[position_lower_case]]
@@ -411,9 +582,12 @@ class MMU3:
     """
 
     def __init__(self, config: ConfigWrapper) -> None:
-        self._last_command_failed = None
-        self._last_command_failed_args = None
-        self._last_command_failed_kwargs = None
+        # recovery state: what the operator is currently asking for
+        # (current_operation) and what failed and is waiting to be retried
+        # (pending_operation). Both are in-memory only and cleared on a
+        # Klipper restart.
+        self.current_operation: None | Operation = None
+        self.pending_operation: None | Operation = None
 
         self.printer: Printer = config.get_printer()
         self.gcode: GCodeDispatch = self.printer.lookup_object("gcode")
@@ -437,7 +611,7 @@ class MMU3:
         self.selector_stepper_endstop: None | MCU_endstop = None
         self.display_status: None | DisplayStatus = None
         self.filament_switch_sensor: None | SwitchSensor = None
-        self.filament_switch_sensor_position: None | SwitchSensorPosition = None
+        self.filament_switch_sensor_position: None | FilamentSwitchSensorPosition = None
         self.filament_motion_sensor: None | EncoderSensor = None
 
         # state variables
@@ -449,6 +623,8 @@ class MMU3:
         self.extruder_temp = None
         self.current_tool = None
         self.current_filament = None
+        # how far the filament tip has moved from the MMU toward the nozzle
+        self.filament_pos = FilamentPos.UNLOADED
 
         # statistics variables
         self.number_of_material_changes = 0
@@ -557,9 +733,10 @@ class MMU3:
         self.unload_retry = config.getint("unload_retry", 5)
         self.tool_change_retry = config.getint("tool_change_retry", 5)
         self.filament_switch_sensor_position = (
-            SwitchSensorPosition.to_switch_sensor_position(
+            FilamentSwitchSensorPosition.to_switch_sensor_position(
                 config.get(
-                    "filament_switch_sensor_position", SwitchSensorPosition.OnGears
+                    "filament_switch_sensor_position",
+                    FilamentSwitchSensorPosition.OnGears,
                 )
             )
         )
@@ -576,6 +753,7 @@ class MMU3:
         # register commands
         self.register_commands()
         self.printer.register_event_handler("klippy:connect", self._connect)
+        self.printer.register_event_handler("klippy:ready", self._handle_ready)
 
     def _connect(self) -> None:
         """Handle klippy:connect event."""
@@ -611,6 +789,30 @@ class MMU3:
             "display_status"
         )
 
+    def _handle_ready(self) -> None:
+        """Handle klippy:ready - reconcile the tracked state with the sensors.
+
+        In-memory state is lost on a restart, so on the way up derive the real
+        filament position from the sensors (e.g. after a firmware restart in the
+        middle of a print the filament is still physically loaded).
+
+        The ``klippy:ready`` handlers run under ``reactor.assert_no_pause()``,
+        but :meth:`assess_filament_pos` queries the FINDA endstop and flushes the
+        lookahead, both of which pause the reactor. Defer the assessment to a
+        reactor callback that fires once the main event loop is running, where
+        pausing is allowed. A failure there must never disturb startup.
+        """
+        self.reactor.register_callback(self._assess_filament_pos_on_ready)
+
+    def _assess_filament_pos_on_ready(self, eventtime: float) -> None:
+        """Run the deferred startup filament-position assessment.
+
+        Args:
+            eventtime (float): The reactor event time (unused).
+        """
+        with contextlib.suppress(Exception):
+            self.assess_filament_pos()
+
     def get_status(self, event_time: float) -> dict:
         """Return the status of the MMU3 for Klipper's template engine.
 
@@ -626,6 +828,12 @@ class MMU3:
             "is_paused": self.is_paused,
             "current_tool": self.current_tool,
             "current_filament": self.current_filament,
+            "filament_pos": self.filament_pos.name,
+            "pending_operation": (
+                self.pending_operation.describe()
+                if self.pending_operation is not None
+                else None
+            ),
         }
 
     def respond_info(self, msg: str) -> None:
@@ -677,6 +885,7 @@ class MMU3:
         self.gcode.register_command("HOME_MMU_ONLY", self.cmd_home_mmu_only)
         self.gcode.register_command("PAUSE_MMU", self.cmd_pause)
         self.gcode.register_command("RESUME_MMU", self.cmd_resume)
+        self.gcode.register_command("MMU_RETRY", self.cmd_mmu_retry)
 
         for i in range(self.number_of_tools):
             self.gcode.register_command(f"T{i}", partial(self.cmd_tx, tool_id=i))
@@ -848,7 +1057,9 @@ class MMU3:
         return orig_trapq
 
     def unsync_stepper_from_extruder(
-        self, manual_stepper: ManualStepper, trapq  # noqa: ANN001
+        self,
+        manual_stepper: ManualStepper,
+        trapq,  # noqa: ANN001
     ) -> None:
         """Unsynchronize the given stepper from the extruder.
 
@@ -897,7 +1108,7 @@ class MMU3:
         self.toolhead.wait_moves()
         self.respond_debug("Doing the fast move")
         # do a big rotation to ensure we hit the end stop
-        # let's try using a homing move...
+        # let's try using a homing move...
         self.idler_stepper.do_homing_move(
             movepos=self.idler_homing_move_lengths[0],
             speed=self.idler_homing_speed,
@@ -919,7 +1130,7 @@ class MMU3:
         self.toolhead.wait_moves()
         self.idler_stepper.do_set_position(0)
 
-        # do a second homing move, but slower
+        # do a second homing move, but slower
         self.idler_stepper.do_homing_move(
             movepos=self.idler_homing_move_lengths[2],
             speed=self.idler_homing_speed / 3,
@@ -1015,6 +1226,7 @@ class MMU3:
 
         self.current_tool = None
         self.current_filament = None
+        self.filament_pos = FilamentPos.UNLOADED
         self.unselect_tool()
         self.is_homed = True
         self.respond_debug("Homing MMU ended ...")
@@ -1085,12 +1297,35 @@ class MMU3:
         self.disable_steppers()
         return True
 
-    def resume(self) -> bool:
-        """Resume the MMU.
+    def resume(self, force: bool = False) -> bool:
+        """Resume the MMU and the print.
+
+        If there is a pending operation left over from a failed load/unload,
+        retry it first and only resume the print if that succeeds. ``force``
+        skips the retry, clears the pending operation and resumes anyway
+        ("I fixed it by hand").
+
+        Args:
+            force (bool): Skip the pending-operation retry.
 
         Returns:
             bool: True if command completed successfully, False otherwise.
         """
+        if self.pending_operation is not None and not force:
+            self.respond_info(
+                f"Pending MMU operation: {self.pending_operation.describe()}"
+            )
+            if not self.retry_pending_operation():
+                self.display_status_msg(
+                    "MMU recovery failed - fix the issue then RESUME_MMU again "
+                    "(or RESUME_MMU FORCE=1 to override)."
+                )
+                return False
+
+        if force:
+            self.pending_operation = None
+            self.current_operation = None
+
         self.is_paused = False
         self.gcode.run_script_from_command(
             """
@@ -1101,6 +1336,216 @@ class MMU3:
         )
         self.toolhead.wait_moves()
         return True
+
+    def _switch_sensor_bounds(
+        self, in_finda: bool, in_switch: bool
+    ) -> tuple[FilamentPos, FilamentPos]:
+        """Return the (floor, ceiling) the sensors allow for ``filament_pos``.
+
+        What the filament switch sensor proves depends on where it sits
+        (``filament_switch_sensor_position``):
+
+        * ``PreGears`` / ``OnGears`` - the sensor is at or before the extruder
+          gears. Triggered proves the filament has reached the gears but cannot
+          tell IN_HOTEND / LOADED apart (the strand keeps the sensor triggered
+          once loaded). Not triggered proves the filament is *not* past the
+          gears, so it is at most AT_FINDA.
+        * ``PostGears`` - the sensor is after the gears. Triggered proves the
+          filament has passed through them (>= IN_HOTEND). Not triggered still
+          allows the tip to be sitting in the gears (AT_EXTRUDER).
+
+        FINDA sits at the MMU output and stays triggered for every loaded
+        state, so ``not in_finda and not in_switch`` is the only unambiguous
+        "unloaded".
+        """
+        post_gears = (
+            self.filament_switch_sensor_position
+            == FilamentSwitchSensorPosition.PostGears
+        )
+        if in_switch:
+            floor = FilamentPos.IN_HOTEND if post_gears else FilamentPos.AT_EXTRUDER
+            return floor, FilamentPos.LOADED
+        if in_finda:
+            ceiling = FilamentPos.AT_EXTRUDER if post_gears else FilamentPos.AT_FINDA
+            return FilamentPos.AT_FINDA, ceiling
+        return FilamentPos.UNLOADED, FilamentPos.UNLOADED
+
+    def assess_filament_pos(self) -> FilamentPos:
+        """Derive the filament position from the physical sensors.
+
+        Clamps ``self.filament_pos`` into the ``[floor, ceiling]`` window the
+        FINDA and filament switch sensor allow (see
+        :meth:`_switch_sensor_bounds`), so it can neither claim more progress
+        than the sensors support nor keep stale progress the sensors have
+        ruled out, and reconciles ``self.current_filament``. This replaces the
+        ad-hoc ``current_filament``-from-FINDA fixups scattered through the
+        unload helpers.
+
+        Returns:
+            FilamentPos: The assessed (and now stored) position.
+        """
+        in_finda = self.is_filament_in_finda()
+        in_switch = self.is_filament_in_switch_sensor()
+
+        floor, ceiling = self._switch_sensor_bounds(in_finda, in_switch)
+        self.filament_pos = min(max(self.filament_pos, floor), ceiling)
+
+        if self.filament_pos == FilamentPos.UNLOADED:
+            self.current_filament = None
+        elif self.current_filament is None:
+            # filament is somewhere in the path; best guess is the selected tool
+            self.current_filament = self.current_tool
+
+        self.respond_debug(
+            f"assess_filament_pos: FINDA={in_finda} switch={in_switch} "
+            f"pos={self.filament_switch_sensor_position} "
+            f"-> {self.filament_pos} (filament T{self.current_filament})"
+        )
+        return self.filament_pos
+
+    def _load_path(self) -> list:
+        """Ordered forward transitions as ``(reached_pos, step_fn)`` pairs."""
+        return [
+            (FilamentPos.AT_FINDA, self.load_filament_to_finda),
+            (FilamentPos.AT_EXTRUDER, self.load_filament_from_finda_to_extruder),
+            (FilamentPos.LOADED, self.load_filament_to_hotend),
+        ]
+
+    def _unload_path(self) -> list:
+        """Ordered reverse transitions as ``(reached_pos, step_fn)`` pairs."""
+        return [
+            (FilamentPos.AT_EXTRUDER, self.unload_filament_from_hotend),
+            (FilamentPos.AT_FINDA, self.unload_filament_from_extruder_to_finda),
+            (FilamentPos.UNLOADED, self.unload_filament_from_finda),
+        ]
+
+    def move_filament_to(
+        self, target_pos: FilamentPos, tool_id: None | int = None
+    ) -> bool:
+        """Run only the sub-steps between the current position and ``target_pos``.
+
+        Shared by the normal load/unload paths and by recovery, so a retry after
+        a mid-load failure continues from where it stopped instead of repeating
+        the whole chain (e.g. a 450 mm bowden move).
+
+        Args:
+            target_pos (FilamentPos): The position to reach.
+            tool_id (None | int): Tool to select before any forward move.
+                Defaults to ``current_tool``; unload sub-steps auto-select from
+                ``current_filament``.
+
+        Returns:
+            bool: True if ``filament_pos`` reached ``target_pos``.
+        """
+        if self.is_paused:
+            return False
+        if self.filament_pos == target_pos:
+            return True
+        if target_pos > self.filament_pos:
+            return self._load_toward(target_pos, tool_id)
+        return self._unload_toward(target_pos)
+
+    def _load_toward(self, target_pos: FilamentPos, tool_id: None | int) -> bool:
+        """Run the forward sub-steps needed to reach ``target_pos``."""
+        if tool_id is None:
+            tool_id = self.current_tool
+        if tool_id is None:
+            self.display_status_msg("Cannot load, no tool selected!")
+            return False
+        if (
+            self.filament_pos <= FilamentPos.AT_FINDA
+            and self.current_tool != tool_id
+            and not self.select_tool(tool_id)
+        ):
+            return False
+        for reached_pos, step_fn in self._load_path():
+            if self.filament_pos < reached_pos <= target_pos and not step_fn():
+                return False
+        return self.filament_pos >= target_pos
+
+    def _unload_toward(self, target_pos: FilamentPos) -> bool:
+        """Run the reverse sub-steps needed to reach ``target_pos``."""
+        for reached_pos, step_fn in self._unload_path():
+            if target_pos <= reached_pos < self.filament_pos and not step_fn():
+                return False
+        return self.filament_pos <= target_pos
+
+    def retry_pending_operation(self) -> bool:
+        """Re-drive ``self.pending_operation`` after checking the sensors.
+
+        Clears ``is_paused`` for the duration so the sub-steps can run, then
+        restores it to reflect whether recovery succeeded.
+
+        Returns:
+            bool: True if the pending operation completed (or there was none).
+        """
+        op = self.pending_operation
+        if op is None:
+            self.display_status_msg("No pending MMU operation to retry.")
+            return True
+
+        self.respond_info(f"Retrying: {op.describe()}")
+        self.is_paused = False
+        ok = False
+        try:
+            self.assess_filament_pos()
+            if op.kind == OperationKind.HOME:
+                ok = self.home_mmu()
+            elif op.kind == OperationKind.CUT and op.to_tool is not None:
+                ok = self.cut_filament_in_mmu(op.to_tool)
+            elif op.kind == OperationKind.TOOL_CHANGE and op.to_tool is not None:
+                ok = self.unload_tool() and self.load_tool(op.to_tool)
+            elif op.kind == OperationKind.LOAD and op.to_tool is not None:
+                ok = self.load_tool(op.to_tool)
+            else:  # UNLOAD / EJECT / degenerate TOOL_CHANGE
+                ok = self.unload_tool()
+        finally:
+            self.is_paused = not ok
+
+        if ok:
+            self.pending_operation = None
+            self.current_operation = None
+            self.display_status_msg(f"{op.describe()} => recovered")
+        return ok
+
+    def show_recovery_prompt(self) -> None:
+        """Show the Mainsail recovery dialog for the pending operation.
+
+        The retry button is generic (``MMU_RETRY``) so the same dialog serves
+        every failure site - the operator never has to remember the original
+        command.
+        """
+        message = (
+            self.pending_operation.describe()
+            if self.pending_operation is not None
+            else "MMU operation failed."
+        )
+        prompt = Prompt(
+            headline="MMU Error",
+            widgets=[
+                Text(text=message),
+                ButtonGroup(
+                    buttons=[
+                        Button(label="Unlock MMU", gcode="UNLOCK_MMU"),
+                        Button(label="Unload Tool", gcode="UT"),
+                    ],
+                ),
+                ButtonGroup(
+                    buttons=[
+                        Button(label="Home MMU", gcode="HOME_MMU"),
+                        Button(
+                            label="Retry",
+                            gcode="PROMPT_CLOSE_AND_RUN_COMMAND COMMAND=MMU_RETRY",
+                        ),
+                    ],
+                ),
+                FooterButton(
+                    label="Resume",
+                    gcode="PROMPT_CLOSE_AND_RUN_COMMAND COMMAND=RESUME_MMU",
+                ),
+            ],
+        )
+        self.gcode.run_script_from_command(prompt.to_gcode())
 
     def unlock(self) -> bool:
         """Park the idler, stop the delayed stop of the heater.
@@ -1265,6 +1710,8 @@ class MMU3:
             self.respond_debug("Filament is not in switch sensor after load!")
             return False
 
+        self.filament_pos = max(self.filament_pos, FilamentPos.IN_HOTEND)
+
         detection_length = 0
         if self.filament_motion_sensor:
             detection_length = self.filament_motion_sensor.detection_length * 2
@@ -1293,6 +1740,7 @@ class MMU3:
             self.respond_debug("Filament is not moving after load!")
             return False
 
+        self.filament_pos = FilamentPos.LOADED
         self.respond_debug("Load Complete")
         return True
 
@@ -1334,6 +1782,7 @@ class MMU3:
 
         if not self.is_filament_in_switch_sensor():
             self.respond_debug("No filament in extruder")
+            self.filament_pos = min(self.filament_pos, FilamentPos.AT_EXTRUDER)
             return True
 
         if self.current_tool is not None:
@@ -1355,7 +1804,10 @@ class MMU3:
         """)
         self.toolhead.wait_moves()
 
-        if self.filament_switch_sensor_position != SwitchSensorPosition.PreGears:
+        if (
+            self.filament_switch_sensor_position
+            != FilamentSwitchSensorPosition.PreGears
+        ):
             if self.is_filament_in_switch_sensor():
                 for _ in range(self.unload_retry):
                     self.retry_unload_filament_from_hotend()
@@ -1363,6 +1815,7 @@ class MMU3:
             if self.is_filament_in_switch_sensor():
                 return False
 
+        self.filament_pos = min(self.filament_pos, FilamentPos.AT_EXTRUDER)
         self.respond_debug("Filament removed")
         return True
 
@@ -1497,8 +1950,8 @@ class MMU3:
         # POST_GEARS: sensor is past the gears; filament must pass through them.
         # Both need ExtruderSynchronizer so the gears turn in sync with the push.
         needs_extruder_sync = self.filament_switch_sensor_position in (
-            SwitchSensorPosition.OnGears,
-            SwitchSensorPosition.PostGears,
+            FilamentSwitchSensorPosition.OnGears,
+            FilamentSwitchSensorPosition.PostGears,
         )
 
         self.display_status_msg("Loading to FINDA for bowden calibration...")
@@ -1609,6 +2062,13 @@ class MMU3:
             self.display_status_msg("Cannot load to FINDA, tool not selected !!")
             return False
 
+        if self.enable_no_selector_mode:
+            # no per-tool FINDA stage in 5in1 mode - the spool feeds straight
+            # to the extruder, mirroring load_filament_to_extruder()
+            self.current_filament = self.current_tool
+            self.filament_pos = max(self.filament_pos, FilamentPos.AT_FINDA)
+            return True
+
         self.respond_debug("Loading filament to FINDA ...")
         if not self.load_filament_to_finda_in_loop():
             self.pulley_stepper.do_set_position(0)
@@ -1620,6 +2080,7 @@ class MMU3:
         #     return False
 
         self.current_filament = self.current_tool
+        self.filament_pos = max(self.filament_pos, FilamentPos.AT_FINDA)
         self.respond_debug("Loading done to FINDA")
         return True
 
@@ -1653,11 +2114,13 @@ class MMU3:
         # Check filament switch sensor after initial bowden move.
         if (
             self.filament_switch_sensor is not None
-            and self.filament_switch_sensor_position != SwitchSensorPosition.PostGears
+            and self.filament_switch_sensor_position
+            != FilamentSwitchSensorPosition.PostGears
         ):
             if self.is_filament_in_switch_sensor():
                 self.respond_debug("Filament detected at sensor")
                 self.respond_debug("Loading done from FINDA to extruder")
+                self.filament_pos = max(self.filament_pos, FilamentPos.AT_EXTRUDER)
                 return True
 
             # Not triggered yet - push incrementally up to load_retry times.
@@ -1681,6 +2144,9 @@ class MMU3:
                     if self.is_filament_in_switch_sensor():
                         self.respond_debug("Filament detected at extruder sensor")
                         self.respond_debug("Loading done from FINDA to extruder")
+                        self.filament_pos = max(
+                            self.filament_pos, FilamentPos.AT_EXTRUDER
+                        )
                         return True
 
             # All retries exhausted, filament never reached sensor.
@@ -1702,6 +2168,7 @@ class MMU3:
             """)
 
         self.respond_debug("Loading done from FINDA to extruder")
+        self.filament_pos = max(self.filament_pos, FilamentPos.AT_EXTRUDER)
         return True
 
     def load_filament_to_extruder(self) -> bool:
@@ -1742,14 +2209,18 @@ class MMU3:
         if self.is_paused:
             return False
 
+        if self.enable_no_selector_mode:
+            # no per-tool FINDA stage in 5in1 mode
+            self.current_filament = None
+            self.filament_pos = FilamentPos.UNLOADED
+            return True
+
         if self.current_tool is None:
             if self.current_filament is not None:
                 # Auto select tool
                 self.select_tool(self.current_filament)
             else:
-                self.display_status_msg(
-                    "Tool not selected, cannot unload from FINDA!"
-                )
+                self.display_status_msg("Tool not selected, cannot unload from FINDA!")
                 return False
 
         self.respond_debug("Unloading filament from FINDA ...")
@@ -1763,6 +2234,7 @@ class MMU3:
         if self.is_filament_in_finda():
             return False
         self.current_filament = None
+        self.filament_pos = FilamentPos.UNLOADED
         self.respond_debug("Unloading done from FINDA")
         return True
 
@@ -1800,7 +2272,8 @@ class MMU3:
             # if the filament sensor is pre-gears, check if we were able to
             # pull the filament out.
             if (
-                self.filament_switch_sensor_position == SwitchSensorPosition.PreGears
+                self.filament_switch_sensor_position
+                == FilamentSwitchSensorPosition.PreGears
                 and self.is_filament_in_switch_sensor()
             ):
                 for _ in range(self.unload_retry):
@@ -1826,6 +2299,7 @@ class MMU3:
                 self.bowden_unload_speed,
                 self.bowden_unload_accel,
             )
+        self.filament_pos = min(self.filament_pos, FilamentPos.AT_FINDA)
         self.respond_debug("Done unloading from FINDA!")
         return True
 
@@ -2019,11 +2493,13 @@ class MMU3:
             return False
 
         self.respond_debug(f"LT {tool_id}")
-        if not self.select_tool(tool_id):
+        if self.filament_pos < FilamentPos.AT_EXTRUDER and not self.select_tool(
+            tool_id
+        ):
             return False
-        if not self.load_filament_to_extruder():
-            return False
-        return self.load_filament_to_hotend()
+        # planner runs only the steps still needed to reach LOADED, so a retry
+        # after a mid-load failure does not repeat the whole bowden move
+        return self.move_filament_to(FilamentPos.LOADED, tool_id)
 
     def unload_tool(self) -> bool:
         """Unload filament from nozzle to MMU3.
@@ -2063,11 +2539,8 @@ class MMU3:
             self.toolhead.wait_moves()
 
         self.respond_debug(f"UT {self.current_filament}")
-        if not self.unload_filament_from_hotend():
-            return False
-        if not self.select_tool(self.current_filament):
-            return False
-        return self.unload_filament_from_extruder()
+        # planner runs only the steps still needed to reach UNLOADED
+        return self.move_filament_to(FilamentPos.UNLOADED, self.current_filament)
 
     def eject_from_extruder(self) -> bool:
         """Preheat the heater if needed and unload the filament with ramming.
@@ -2159,6 +2632,7 @@ class MMU3:
         return self.home_idler()
 
     @auto_pause
+    @track_operation(OperationKind.HOME)
     @measure_duration
     @auto_disable_steppers
     def cmd_home_mmu(self, gcmd: GCodeCommand) -> bool:
@@ -2230,7 +2704,9 @@ class MMU3:
         return self.pause()
 
     def cmd_resume(self, gcmd: GCodeCommand) -> bool:
-        """Resume the MMU.
+        """Resume the MMU and the print.
+
+        ``FORCE=1`` clears any pending operation and resumes without retrying it.
 
         Args:
             gcmd: (GCodeCommand): The G-code command.
@@ -2242,9 +2718,26 @@ class MMU3:
             self.display_status_msg("MMU is not enabled!")
             return True
 
-        return self.resume()
+        return self.resume(force=bool(gcmd.get_int("FORCE", 0)))
 
     @auto_pause
+    @auto_disable_steppers
+    def cmd_mmu_retry(self, gcmd: GCodeCommand) -> bool:
+        """Retry the operation that failed and left the MMU paused.
+
+        Reads ``pending_operation`` so the operator does not have to remember
+        the original command (e.g. which ``Tx``).
+
+        Args:
+            gcmd (GCodeCommand): The G-code command.
+
+        Returns:
+            bool: True if the pending operation completed, False otherwise.
+        """
+        return self.retry_pending_operation()
+
+    @auto_pause
+    @track_operation(OperationKind.TOOL_CHANGE)
     @measure_duration
     @auto_disable_steppers
     def cmd_tx(self, gcmd: GCodeCommand, tool_id: int = 0) -> bool:
@@ -2265,7 +2758,11 @@ class MMU3:
             status_message = f"T{tool_id}"
         self.display_status_msg(status_message)
 
-        if self.current_filament == tool_id:
+        # sync the tracked position with the sensors before planning so the
+        # planner cannot skip steps because of stale state
+        self.assess_filament_pos()
+
+        if self.current_filament == tool_id and self.filament_pos == FilamentPos.LOADED:
             return True
 
         with (
@@ -2287,6 +2784,9 @@ class MMU3:
             for i in range(self.tool_change_retry):
                 if i > 0:
                     self.display_status_msg(f"Retry ({i + 1}): T{tool_id}...")
+                    # re-sync the tracked position with the sensors so the
+                    # planner resumes from where the filament actually is
+                    self.assess_filament_pos()
 
                 if i in range(1, self.tool_change_retry - 1):
                     # on last try we'll home the mmu
@@ -2305,42 +2805,12 @@ class MMU3:
                     continue
                 break
             else:
-                # so the load did not happen...
+                # all retries exhausted - auto_pause promotes the tracked
+                # operation to pending_operation and shows the recovery prompt
                 if previous_filament is not None:
-                    error_message = f"T{previous_filament} => T{tool_id} failed!"
+                    self.respond_debug(f"T{previous_filament} => T{tool_id} failed!")
                 else:
-                    error_message = f"T{tool_id} failed!"
-                self.respond_debug(error_message)
-
-                # display a prompt in Mainsail UI
-                prompt = Prompt(
-                    headline="MMU Error",
-                    widgets=[
-                        Text(text=error_message),
-                        # Add possible commands,
-                        ButtonGroup(
-                            buttons=[
-                                Button(label="Unlock MMU", gcode="UNLOCK_MMU"),
-                                Button(label="Unload Tool", gcode="UT"),
-                            ],
-                        ),
-                        ButtonGroup(
-                            buttons=[
-                                Button(label="Home MMU", gcode="HOME_MMU"),
-                                Button(
-                                    label=f"Retry T{tool_id}",
-                                    gcode="PROMPT_CLOSE_AND_RUN_COMMAND "
-                                    f"COMMAND=T{tool_id}",
-                                ),
-                            ],
-                        ),
-                        FooterButton(
-                            label="Resume",
-                            gcode="PROMPT_CLOSE_AND_RUN_COMMAND COMMAND=RESUME",
-                        ),
-                    ],
-                )
-                self.gcode.run_script_from_command(prompt.to_gcode())
+                    self.respond_debug(f"T{tool_id} failed!")
                 return False
 
         if previous_filament is not None:
@@ -2350,6 +2820,7 @@ class MMU3:
         return True
 
     @auto_pause
+    @track_operation(OperationKind.CUT)
     @auto_disable_steppers
     def cmd_kx(self, gcmd: GCodeCommand, tool_id: int = 0) -> bool:
         """The generic Kx command.
@@ -2373,6 +2844,7 @@ class MMU3:
         return self.unlock()
 
     @auto_pause
+    @track_operation(OperationKind.LOAD)
     @measure_duration
     @auto_disable_steppers
     def cmd_load_tool(self, gcmd: GCodeCommand) -> bool:
@@ -2385,9 +2857,11 @@ class MMU3:
             bool: True if command completed successfully, False otherwise.
         """
         tool_id = gcmd.get_int("VALUE", None)
+        self.assess_filament_pos()
         return self.load_tool(tool_id)
 
     @auto_pause
+    @track_operation(OperationKind.UNLOAD)
     @measure_duration
     @auto_disable_steppers
     def cmd_unload_tool(self, gcmd: GCodeCommand) -> bool:
@@ -2415,6 +2889,7 @@ class MMU3:
                 self.toolhead,
             ),
         ):
+            self.assess_filament_pos()
             return self.unload_tool()
 
     @auto_pause
@@ -2512,6 +2987,7 @@ class MMU3:
         return self.unload_filament_from_hotend()
 
     @auto_pause
+    @track_operation(OperationKind.EJECT)
     @auto_disable_steppers
     def cmd_eject_ramming(self, gcmd: GCodeCommand) -> bool:
         """Eject the filament with ramming from the extruder nozzle to the MMU3.
@@ -2628,6 +3104,7 @@ class MMU3:
         return self.unload_filament_from_extruder()
 
     @auto_pause
+    @track_operation(OperationKind.UNLOAD)
     @auto_disable_steppers
     def cmd_m702(self, gcmd: GCodeCommand) -> bool:
         """Unload filament if inserted into the IR sensor.
@@ -2655,6 +3132,7 @@ class MMU3:
         return True
 
     @auto_pause
+    @track_operation(OperationKind.EJECT)
     @auto_disable_steppers
     def cmd_eject_from_extruder(self, gcmd: GCodeCommand) -> bool:
         """Preheat the heater if needed and unload the filament with ramming.

--- a/mmu3_menus.cfg
+++ b/mmu3_menus.cfg
@@ -9,6 +9,13 @@ name: Unlock MMU
 gcode:
     UNLOCK_MMU
 
+[menu __main __mmu __retry]
+type: command
+enable: {printer['mmu3 MMU3'].is_enabled and printer['mmu3 MMU3'].pending_operation is not none}
+name: Retry MMU Op
+gcode:
+    MMU_RETRY
+
 [menu __main __mmu __home_mmu]
 type: command
 enable: {printer['mmu3 MMU3'].is_enabled}

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -4,7 +4,7 @@
 import pytest
 
 # Local Imports
-from mainsail_prompts import Button, Color
+from extras.mmu3_mainsail_prompts import Button, Color
 
 
 @pytest.mark.parametrize(

--- a/tests/test_button_group.py
+++ b/tests/test_button_group.py
@@ -4,7 +4,7 @@
 import pytest
 
 # Local Imports
-from mainsail_prompts import Button, ButtonGroup, Color
+from extras.mmu3_mainsail_prompts import Button, ButtonGroup, Color
 
 
 @pytest.mark.parametrize(

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -8,7 +8,7 @@ from enum import Enum
 import pytest
 
 # Local imports
-from mainsail_prompts import Color
+from extras.mmu3_mainsail_prompts import Color
 
 
 

--- a/tests/test_footer_button.py
+++ b/tests/test_footer_button.py
@@ -4,7 +4,7 @@
 import pytest
 
 # Local Imports
-from mainsail_prompts import FooterButton, Color
+from extras.mmu3_mainsail_prompts import FooterButton, Color
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mainsail_prompt_base.py
+++ b/tests/test_mainsail_prompt_base.py
@@ -4,7 +4,7 @@
 import pytest
 
 # Local Imports
-from mainsail_prompts import MainsailPromptBase
+from extras.mmu3_mainsail_prompts import MainsailPromptBase
 
 
 

--- a/tests/test_mmu3_recovery.py
+++ b/tests/test_mmu3_recovery.py
@@ -1,0 +1,296 @@
+"""Tests for the MMU3 recovery state machine.
+
+Covers the pure-logic pieces added for issue #41: the ``Operation`` record,
+the ``FilamentPos`` ordering, the ``move_filament_to`` planner step selection
+and ``assess_filament_pos`` sensor reconciliation.
+"""
+
+# Standard Library Imports
+import sys
+import types
+
+# Third-Party Imports
+import pytest
+
+# The real module imports Klipper's ``extras.manual_stepper``; stub it so the
+# module under test can be imported standalone.
+sys.modules.setdefault(
+    "extras.manual_stepper",
+    types.SimpleNamespace(ManualStepper=object),
+)
+
+# Local Imports
+from extras.mmu3 import (  # noqa: E402
+    MMU3,
+    FilamentPos,
+    FilamentSwitchSensorPosition,
+    Operation,
+    OperationKind,
+)
+
+
+def make_mmu() -> MMU3:
+    """Build a bare MMU3 instance without running __init__ or touching Klipper."""
+    mmu = object.__new__(MMU3)
+    mmu.is_paused = False
+    mmu.filament_pos = FilamentPos.UNLOADED
+    mmu.current_tool = None
+    mmu.current_filament = None
+    mmu.enable_no_selector_mode = False
+    mmu.calls = []
+    mmu.display_status_msg = lambda msg: mmu.calls.append(("msg", msg))
+    mmu.respond_debug = lambda msg: None
+    mmu.respond_info = lambda msg: None
+
+    def select_tool(tool_id: int) -> bool:
+        mmu.calls.append(("select", tool_id))
+        mmu.current_tool = tool_id
+        return True
+
+    mmu.select_tool = select_tool
+
+    # each fake sub-step records itself and advances/retreats filament_pos
+    def step(name: str, reached: FilamentPos):
+        def _step() -> bool:
+            mmu.calls.append((name, reached))
+            mmu.filament_pos = reached
+            return True
+
+        return _step
+
+    mmu.load_filament_to_finda = step("to_finda", FilamentPos.AT_FINDA)
+    mmu.load_filament_from_finda_to_extruder = step(
+        "finda_to_extruder", FilamentPos.AT_EXTRUDER
+    )
+    mmu.load_filament_to_hotend = step("to_hotend", FilamentPos.LOADED)
+    mmu.unload_filament_from_hotend = step("from_hotend", FilamentPos.AT_EXTRUDER)
+    mmu.unload_filament_from_extruder_to_finda = step(
+        "extruder_to_finda", FilamentPos.AT_FINDA
+    )
+    mmu.unload_filament_from_finda = step("from_finda", FilamentPos.UNLOADED)
+    return mmu
+
+
+# ---------------------------------------------------------------------------
+# FilamentPos
+# ---------------------------------------------------------------------------
+def test_filament_pos_is_ordered() -> None:
+    assert FilamentPos.UNLOADED < FilamentPos.AT_FINDA < FilamentPos.AT_EXTRUDER
+    assert FilamentPos.AT_EXTRUDER < FilamentPos.IN_HOTEND < FilamentPos.LOADED
+    assert max(FilamentPos.AT_FINDA, FilamentPos.LOADED) is FilamentPos.LOADED
+
+
+# ---------------------------------------------------------------------------
+# Operation
+# ---------------------------------------------------------------------------
+def test_operation_describe_tool_change_with_stage() -> None:
+    op = Operation(OperationKind.TOOL_CHANGE, from_tool=1, to_tool=2)
+    op.filament_pos_at_fail = FilamentPos.AT_EXTRUDER
+    assert op.describe() == (
+        "Tool change T1 => T2 - stopped with filament at the extruder"
+    )
+
+
+def test_operation_describe_first_load_has_no_from_tool() -> None:
+    op = Operation(OperationKind.TOOL_CHANGE, from_tool=None, to_tool=3)
+    assert op.describe() == "Load T3"
+
+
+def test_operation_describe_includes_error() -> None:
+    op = Operation(OperationKind.UNLOAD, from_tool=4)
+    op.error = "FINDA still triggered"
+    assert op.describe() == "Unload T4 (FINDA still triggered)"
+
+
+@pytest.mark.parametrize(
+    "kind,to_tool,expected",
+    [
+        (OperationKind.TOOL_CHANGE, 2, FilamentPos.LOADED),
+        (OperationKind.LOAD, 0, FilamentPos.LOADED),
+        (OperationKind.TOOL_CHANGE, None, FilamentPos.UNLOADED),
+        (OperationKind.UNLOAD, None, FilamentPos.UNLOADED),
+        (OperationKind.EJECT, None, FilamentPos.UNLOADED),
+        (OperationKind.HOME, None, FilamentPos.UNLOADED),
+    ],
+)
+def test_operation_target_pos(kind, to_tool, expected):
+    assert Operation(kind, to_tool=to_tool).target_pos is expected
+
+
+# ---------------------------------------------------------------------------
+# move_filament_to planner
+# ---------------------------------------------------------------------------
+def test_full_load_from_unloaded_runs_every_step() -> None:
+    mmu = make_mmu()
+    assert mmu.move_filament_to(FilamentPos.LOADED, tool_id=2) is True
+    assert mmu.calls == [
+        ("select", 2),
+        ("to_finda", FilamentPos.AT_FINDA),
+        ("finda_to_extruder", FilamentPos.AT_EXTRUDER),
+        ("to_hotend", FilamentPos.LOADED),
+    ]
+
+
+def test_load_resumes_from_broken_step_without_repeating_bowden() -> None:
+    mmu = make_mmu()
+    mmu.current_tool = 2
+    mmu.filament_pos = FilamentPos.AT_EXTRUDER  # bowden move already done
+    assert mmu.move_filament_to(FilamentPos.LOADED, tool_id=2) is True
+    # only the hotend step runs, no re-select and no bowden move
+    assert mmu.calls == [("to_hotend", FilamentPos.LOADED)]
+
+
+def test_partial_load_stops_at_target() -> None:
+    mmu = make_mmu()
+    assert mmu.move_filament_to(FilamentPos.AT_EXTRUDER, tool_id=1) is True
+    assert [c[0] for c in mmu.calls] == ["select", "to_finda", "finda_to_extruder"]
+
+
+def test_full_unload_from_loaded_runs_every_step() -> None:
+    mmu = make_mmu()
+    mmu.filament_pos = FilamentPos.LOADED
+    mmu.current_filament = 3
+    assert mmu.move_filament_to(FilamentPos.UNLOADED) is True
+    assert [c[0] for c in mmu.calls] == [
+        "from_hotend",
+        "extruder_to_finda",
+        "from_finda",
+    ]
+
+
+def test_unload_resumes_from_finda_only() -> None:
+    mmu = make_mmu()
+    mmu.filament_pos = FilamentPos.AT_FINDA
+    assert mmu.move_filament_to(FilamentPos.UNLOADED) is True
+    assert [c[0] for c in mmu.calls] == ["from_finda"]
+
+
+def test_move_is_a_noop_when_already_at_target() -> None:
+    mmu = make_mmu()
+    mmu.filament_pos = FilamentPos.LOADED
+    assert mmu.move_filament_to(FilamentPos.LOADED, tool_id=1) is True
+    assert mmu.calls == []
+
+
+def test_move_fails_fast_when_paused() -> None:
+    mmu = make_mmu()
+    mmu.is_paused = True
+    assert mmu.move_filament_to(FilamentPos.LOADED, tool_id=1) is False
+    assert mmu.calls == []
+
+
+def test_load_needs_a_tool() -> None:
+    mmu = make_mmu()
+    assert mmu.move_filament_to(FilamentPos.LOADED) is False
+    assert ("msg", "Cannot load, no tool selected!") in mmu.calls
+
+
+def test_load_step_failure_aborts_planner() -> None:
+    mmu = make_mmu()
+
+    def failing() -> bool:
+        mmu.calls.append(("finda_to_extruder", "FAIL"))
+        return False
+
+    mmu.load_filament_from_finda_to_extruder = failing
+    assert mmu.move_filament_to(FilamentPos.LOADED, tool_id=1) is False
+    assert [c[0] for c in mmu.calls] == ["select", "to_finda", "finda_to_extruder"]
+
+
+# ---------------------------------------------------------------------------
+# assess_filament_pos
+# ---------------------------------------------------------------------------
+def assess_mmu(
+    in_finda: bool,
+    in_switch: bool,
+    tracked: FilamentPos,
+    sensor_position: FilamentSwitchSensorPosition = (
+        FilamentSwitchSensorPosition.OnGears
+    ),
+) -> MMU3:
+    mmu = object.__new__(MMU3)
+    mmu.filament_pos = tracked
+    mmu.current_tool = 1
+    mmu.current_filament = 1
+    mmu.filament_switch_sensor_position = sensor_position
+    mmu.respond_debug = lambda msg: None
+    mmu.is_filament_in_finda = lambda: in_finda
+    mmu.is_filament_in_switch_sensor = lambda: in_switch
+    return mmu
+
+
+def test_assess_no_sensors_means_unloaded() -> None:
+    mmu = assess_mmu(False, False, FilamentPos.LOADED)
+    assert mmu.assess_filament_pos() is FilamentPos.UNLOADED
+    assert mmu.current_filament is None
+
+
+def test_assess_finda_only_means_at_finda() -> None:
+    mmu = assess_mmu(True, False, FilamentPos.LOADED)
+    assert mmu.assess_filament_pos() is FilamentPos.AT_FINDA
+
+
+def test_assess_both_sensors_keeps_tracked_progress_clamped() -> None:
+    mmu = assess_mmu(True, True, FilamentPos.LOADED)
+    assert mmu.assess_filament_pos() is FilamentPos.LOADED
+
+    mmu = assess_mmu(True, True, FilamentPos.AT_FINDA)
+    assert mmu.assess_filament_pos() is FilamentPos.AT_EXTRUDER
+
+
+def test_assess_recovers_current_filament_from_selected_tool() -> None:
+    mmu = assess_mmu(True, False, FilamentPos.AT_FINDA)
+    mmu.current_filament = None
+    mmu.assess_filament_pos()
+    assert mmu.current_filament == 1
+
+
+# --- FilamentSwitchSensorPosition-specific inference ------------------------
+@pytest.mark.parametrize(
+    "sensor_position",
+    [FilamentSwitchSensorPosition.PreGears, FilamentSwitchSensorPosition.OnGears],
+)
+def test_assess_pre_and_on_gears_cannot_confirm_hotend(sensor_position) -> None:
+    # switch triggered, but a pre/on-gears sensor cannot tell IN_HOTEND from
+    # LOADED - a stale UNLOADED is only bumped up to AT_EXTRUDER
+    mmu = assess_mmu(True, True, FilamentPos.UNLOADED, sensor_position)
+    assert mmu.assess_filament_pos() is FilamentPos.AT_EXTRUDER
+    # ... and real forward progress is preserved
+    mmu = assess_mmu(True, True, FilamentPos.LOADED, sensor_position)
+    assert mmu.assess_filament_pos() is FilamentPos.LOADED
+
+
+def test_assess_post_gears_confirms_past_the_gears() -> None:
+    # switch after the gears: triggered proves the filament passed through them
+    mmu = assess_mmu(
+        True, True, FilamentPos.UNLOADED, FilamentSwitchSensorPosition.PostGears
+    )
+    assert mmu.assess_filament_pos() is FilamentPos.IN_HOTEND
+
+
+def test_assess_post_gears_not_triggered_allows_tip_in_gears() -> None:
+    # not past the gears yet, but the tip may be sitting in them
+    mmu = assess_mmu(
+        True, False, FilamentPos.AT_EXTRUDER, FilamentSwitchSensorPosition.PostGears
+    )
+    assert mmu.assess_filament_pos() is FilamentPos.AT_EXTRUDER
+
+
+@pytest.mark.parametrize(
+    "sensor_position",
+    [
+        FilamentSwitchSensorPosition.PreGears,
+        FilamentSwitchSensorPosition.OnGears,
+        FilamentSwitchSensorPosition.PostGears,
+    ],
+)
+def test_assess_switch_clear_rules_out_stale_hotend_progress(sensor_position) -> None:
+    # tracked says IN_HOTEND but the switch is clear and only FINDA sees
+    # filament - every sensor position agrees the tip is no further than the
+    # gears, and pre/on-gears pull it all the way back to AT_FINDA
+    mmu = assess_mmu(True, False, FilamentPos.IN_HOTEND, sensor_position)
+    result = mmu.assess_filament_pos()
+    if sensor_position == FilamentSwitchSensorPosition.PostGears:
+        assert result is FilamentPos.AT_EXTRUDER
+    else:
+        assert result is FilamentPos.AT_FINDA

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -4,7 +4,7 @@
 import pytest
 
 # Local Imports
-from mainsail_prompts import Button, ButtonGroup, Color, FooterButton, Prompt
+from extras.mmu3_mainsail_prompts import Button, ButtonGroup, Color, FooterButton, Prompt
 
 
 @pytest.mark.parametrize(

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,7 +1,7 @@
 """Tests for the Text class."""
 
 # Local Imports
-from mainsail_prompts import Text
+from extras.mmu3_mainsail_prompts import Text
 
 
 def test_to_gcode_returns_the_gcode_command():


### PR DESCRIPTION
Closes #41.

## What

Recovery from a failed filament load/unload no longer depends on the operator remembering what was in progress. The MMU now records the high-level operation and the verified filament position, and drives retry/resume from that state.

### Part 1 — pending-operation record + intent-aware resume/retry
- `Operation` value object (`kind`, `from_tool`, `to_tool`, `filament_pos_at_fail`, `error`) with `describe()`; `OperationKind` enum.
- `track_operation` decorator on the top-level `cmd_*` handlers records the operation in progress. `auto_pause` promotes it to `pending_operation` on failure, stamping the error and filament position, and shows **one shared recovery prompt** from every failure site (not just `cmd_tx`).
- New **`MMU_RETRY`** command re-drives the pending operation — no tool id needed.
- `resume()` runs the retry first and only `RESUME`s the print when it succeeds. **`RESUME_MMU FORCE=1`** clears the pending op and resumes anyway ("I fixed it by hand").
- `get_status()` exposes `pending_operation` and `filament_pos`.
- Removed the dead `_last_command_failed*` scaffolding.

### Part 2 — verified filament-position state machine
- `FilamentPos` enum (`UNLOADED < AT_FINDA < AT_EXTRUDER < IN_HOTEND < LOADED`), recorded at each existing sub-step boundary — no new movement code.
- `assess_filament_pos()` derives the real position from the FINDA / switch / motion sensors and reconciles `current_filament`, replacing the scattered ad-hoc FINDA fixups. It is **position-aware** by `filament_switch_sensor_position`:
  - `PreGears` / `OnGears` — a triggered switch cannot tell `IN_HOTEND` from `LOADED`, so it only proves `>= AT_EXTRUDER`.
  - `PostGears` — a triggered switch proves the filament passed the gears (`>= IN_HOTEND`).
  - Runs on a deferred reactor callback at startup and before each recovery attempt.
- `move_filament_to(target_pos, tool_id)` planner runs only the sub-steps between the verified current position and the target. `load_tool`, `unload_tool` and `cmd_tx` share it for both the normal and the recovery path, so a retry continues from the broken step instead of repeating the ~450 mm bowden move.

State is **in-memory only** — a Klipper restart clears it and the operator re-issues the tool change. No `[save_variables]` persistence.

## Notes
- Also fixes stale `mainsail_prompts` imports in the existing prompt tests (module was renamed to `extras/mmu3_mainsail_prompts`), which had broken suite collection. Split into its own commit.
- The startup assessment is deferred via `reactor.register_callback` because `klippy:ready` handlers run under `assert_no_pause()` and the FINDA endstop query / lookahead flush would pause the reactor.

## Testing
- `pytest` — **98 passed**. Adds `tests/test_mmu3_recovery.py` (30 tests): `Operation.describe()` / `target_pos`, `FilamentPos` ordering, `move_filament_to` step selection (including resume-from-broken-step, no-tool failure, paused fail-fast, step-failure abort), and `assess_filament_pos` sensor reconciliation across all three `FilamentSwitchSensorPosition` values.
- Bench-tested on-printer by @eoyilmaz: pause / status / generic dialog / `MMU_RETRY` resume-from-position / auto-`RESUME` after clearing the fault all behave as expected.
- `enable_no_selector_mode` (5-in-1) FINDA sub-steps were adjusted to keep planner behaviour equivalent, but that mode is not bench-verified.